### PR TITLE
Restoring day gutter (on hover) to enable click to create

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -225,8 +225,13 @@ body, span, div, dt {
   border-color: #efefef !important;
 }
 
-/* Essentially the chip width? */
+/* Show the clickable create gutter when hovering */
+.tg-col:hover .tg-gutter, .tg-col-today:hover .tg-gutter {
+  margin-right: 10px !important;
+}
+
 .tg-gutter {
+  transition: margin 0.1s ease-in-out;
   margin-right: 0 !important;
 }
 


### PR DESCRIPTION
I know that you can create events with the create button :-) However, the click to create is nice, and the picasso css removed the clickable margin when there's already an event in that space:

<img width="63" alt="screen shot 2017-05-16 at 9 43 18 am" src="https://cloud.githubusercontent.com/assets/627/26117707/3e82305c-3a1c-11e7-8a96-0b56f3ae6a27.png"> ⬅ vs ➡ <img width="30" alt="screen shot 2017-05-16 at 9 43 55 am" src="https://cloud.githubusercontent.com/assets/627/26117878/caddadec-3a1c-11e7-92f0-3b4ed5c1f68b.png">

that gutter is helpful to me (though I agree it looks meh).  I've been using it with a show/hide transition for a few weeks and am enjoying it, so I figured I'd see if you wanted to add it in :-)  No rush or expectations at all.